### PR TITLE
new: Added creation and deletion method for comments and bundles.

### DIFF
--- a/pyvulnerabilitylookup/api.py
+++ b/pyvulnerabilitylookup/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib.metadata import version
 from pathlib import PurePosixPath
-from typing import Any
+from typing import Any, Dict
 from urllib.parse import urljoin, urlparse
 
 import requests
@@ -12,7 +12,7 @@ import requests
 
 class PyVulnerabilityLookup():
 
-    def __init__(self, root_url: str, useragent: str | None=None,
+    def __init__(self, root_url: str, useragent: str | None=None, token: str | None=None,
                  *, proxies: dict[str, str] | None=None) -> None:
         '''Query a specific instance.
 
@@ -28,6 +28,9 @@ class PyVulnerabilityLookup():
             self.root_url += '/'
         self.session = requests.session()
         self.session.headers['user-agent'] = useragent if useragent else f'PyProject / {version("pyvulnerabilitylookup")}'
+        self.session.headers['X-API-KEY'] = token if token else ''
+        self.session.headers['Accept'] = 'application/json'
+        self.session.headers['Content-Type'] = 'application/json'
         if proxies:
             self.session.proxies.update(proxies)
 
@@ -96,16 +99,42 @@ class PyVulnerabilityLookup():
 
     # NOTE: endpoints /api/cve/*, /api/dbInfo, /api/last are alises for backward compat.
 
+    def create_comment(self, comment: Dict[str, Any]) -> Dict[str, Any]:
+        '''Create a comment.
+
+        :param comment: The comment
+        '''
+        r = self.session.post(urljoin(self.root_url, str(PurePosixPath('api', 'comment'))),
+                             json=comment)
+        return r.json()
+
     def get_comments(self, uuid: str | None = None, vuln_id: str | None = None,
                      author: str | None = None) -> dict[str, Any]:
         '''Get comment(s)
 
-        :param uuid: The UUID a specific comment
+        :param uuid: The UUID of a specific comment
         :param vuln_id: The vulnerability ID to get comments of
         :param author: The author of the comment(s)
         '''
         r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'comment'))),
                              params={'uuid': uuid, 'vuln_id': vuln_id, 'author': author})
+        return r.json()
+
+    def delete_comment(self, comment_uuid: str) -> int:
+        '''Delete a comment.
+
+        :param comment_uuid: The comment UUID
+        '''
+        r = self.session.delete(urljoin(self.root_url, str(PurePosixPath('api', 'comment', comment_uuid))))
+        return r.status_code
+
+    def create_bundle(self, bundle: Dict[str, Any]) -> Dict[str, Any]:
+        '''Create a bundle.
+
+        :param bundle: The bundle
+        '''
+        r = self.session.post(urljoin(self.root_url, str(PurePosixPath('api', 'bundle'))),
+                             json=bundle)
         return r.json()
 
     def get_bundles(self, uuid: str | None = None, vuln_id: str | None = None,
@@ -119,3 +148,11 @@ class PyVulnerabilityLookup():
         r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'bundle'))),
                              params={'uuid': uuid, 'vuln_id': vuln_id, 'author': author})
         return r.json()
+
+    def delete_bundle(self, bundle_uuid: str) -> int:
+        '''Delete a bundle.
+
+        :param bundle_uuid: The bundle UUID
+        '''
+        r = self.session.delete(urljoin(self.root_url, str(PurePosixPath('api', 'bundle', bundle_uuid))))
+        return r.status_code

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2,6 +2,7 @@
 
 import unittest
 import time
+import os
 
 from pyvulnerabilitylookup import PyVulnerabilityLookup
 
@@ -9,7 +10,8 @@ from pyvulnerabilitylookup import PyVulnerabilityLookup
 class TestPublic(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.client = PyVulnerabilityLookup(root_url="https://vulnerability.circl.lu")
+        token = os.getenv("API_KEY", "")
+        self.client = PyVulnerabilityLookup(root_url="https://vulnerability.circl.lu", token=token)
 
     #  Test default
 


### PR DESCRIPTION
Small changes for the creation and deletion of comments and bundles.
Tested here:

https://github.com/cve-search/vulnerability-lookup/blob/tests/tests/test_web.py#L84

and deletion:
https://github.com/cve-search/vulnerability-lookup/blob/tests/tests/test_web.py#L110


in a new branch of vuln-lookup I did these changes in the GitHub workflow for the tests:

- https://github.com/cve-search/vulnerability-lookup/blob/tests/.github/workflows/test_api.yml#L77
- https://github.com/cve-search/vulnerability-lookup/blob/tests/.github/workflows/test_api.yml#L106


All the tests in vuln-lookup pass with success. Just not tested the GH workflow for now.