### PR TITLE
Harmonization of some endpoints

### DIFF
--- a/pyvulnerabilitylookup/api.py
+++ b/pyvulnerabilitylookup/api.py
@@ -121,7 +121,7 @@ class PyVulnerabilityLookup():
             path /= source
         if number is not None:
             path /= str(number)
-        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability', 'last'))))
+        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability', path))))
         return r.json()
 
     def get_vendors(self) -> list[str]:

--- a/pyvulnerabilitylookup/api.py
+++ b/pyvulnerabilitylookup/api.py
@@ -62,19 +62,19 @@ class PyVulnerabilityLookup():
 
     def redis_up(self) -> bool:
         '''Check if redis is up and running'''
-        r = self.session.get(urljoin(self.root_url, 'redis_up'))
+        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'system','redis_up'))))
         return r.json()
 
     # #### DB status ####
 
     def get_info(self) -> dict[str, Any]:
         '''Get more information about the current databases in use and when it was updated'''
-        r = self.session.get(urljoin(self.root_url, 'info'))
+        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'system','dbInfo'))))
         return r.json()
 
     def get_config_info(self) -> dict[str, Any]:
         '''Get more information about the current databases in use and when it was updated'''
-        r = self.session.get(urljoin(self.root_url, 'configInfo'))
+        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'system', 'configInfo'))))
         return r.json()
 
     # #### Vulnerabilities ####
@@ -84,7 +84,7 @@ class PyVulnerabilityLookup():
 
         :param vulnerability_id: The ID of the vulnerability to get (can be from any source, as long as it is a valid ID)
         '''
-        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('vulnerability', vulnerability_id))))
+        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability', vulnerability_id))))
         return r.json()
 
     def create_vulnerability(self, vulnerability: dict[str, Any]) -> dict[str, Any]:
@@ -92,7 +92,7 @@ class PyVulnerabilityLookup():
 
         :param vulnerability: The vulnerability
         '''
-        r = self.session.post(urljoin(self.root_url, str(PurePosixPath('vulnerability'))),
+        r = self.session.post(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability'))),
                               json=vulnerability)
         return r.json()
 
@@ -101,7 +101,7 @@ class PyVulnerabilityLookup():
 
         :param vulnerability_id: The vulnerability ID
         '''
-        r = self.session.delete(urljoin(self.root_url, str(PurePosixPath('vulnerability', vulnerability_id))))
+        r = self.session.delete(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability', vulnerability_id))))
         return r.status_code
 
     def get_last(self, number: int | None=None, source: str | None = None) -> list[dict[str, Any]]:
@@ -115,12 +115,12 @@ class PyVulnerabilityLookup():
             path /= source
         if number is not None:
             path /= str(number)
-        r = self.session.get(urljoin(self.root_url, str(path)))
+        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability', 'last'))))
         return r.json()
 
     def get_vendors(self) -> list[str]:
         '''Get the  known vendors'''
-        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'browse'))))
+        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability', 'browse'))))
         return r.json()
 
     def get_vendor_products(self, vendor: str) -> list[str]:
@@ -128,7 +128,7 @@ class PyVulnerabilityLookup():
 
         :params vendor: A vendor owning products (must be in the known vendor list)
         '''
-        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'browse', vendor))))
+        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability', 'browse', vendor))))
         return r.json()
 
     def get_vendor_product_vulnerabilities(self, vendor: str, product: str) -> list[str]:
@@ -137,7 +137,7 @@ class PyVulnerabilityLookup():
         :param vendor: A vendor owning products (must be in the known vendor list)
         :param product: A product owned by that vendor
         '''
-        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'search', vendor, product))))
+        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability', 'browse', vendor, product))))
         return r.json()
 
     # #### Comments ####

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -298,7 +298,7 @@ class TestPublic(unittest.TestCase):
         if not instance_config.get('registration'):
             return None
 
-        user = self.client.create_user(name='test Name', login='alan11111',
+        user = self.client.create_user(name='test Name', login='alan',
                                        organisation='test Organization', email='test@testorg.lu')
         self.assertTrue(user)
         self.assertTrue('id' in user, user)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -293,7 +293,7 @@ class TestPublic(unittest.TestCase):
         if not instance_config.get('registration'):
             return None
 
-        user = self.client.create_user(name='test Name', login='test Login',
+        user = self.client.create_user(name='test Name', login='alan',
                                        organisation='test Organization', email='test@testorg.lu')
         self.assertTrue(user)
         self.assertTrue('login' in user, user)
@@ -307,7 +307,7 @@ class TestPublic(unittest.TestCase):
         created_comment = self.client.create_comment(comment=comment)
         new_comment_uuid = created_comment['data'][0]['uuid']
         comments = self.client.get_comments(uuid=new_comment_uuid)
-        self.assertTrue(len(comments['data']) == 0, comments)
+        self.assertTrue(len(comments['data']) == 1, comments)
         deleted_comment = self.client.delete_comment(new_comment_uuid)
         self.assertTrue(deleted_comment < 300)
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -267,7 +267,7 @@ class TestPublic(unittest.TestCase):
         instance_config = self.client.get_config_info()
         if not instance_config.get('registration'):
             return None
-        for login in ["login", "user", "username", "help", "test", "about", "administration", "account"]:
+        for login in ['login', 'user', 'username', 'help', 'test', 'about', 'administration', 'account']:
             user = self.client.create_user(name='test Name', login=login,
                                         organisation='test Organization', email='test@testorg.local')
             self.assertEqual(user['message'], 'Username not allowed.')

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -260,6 +260,18 @@ class TestPublic(unittest.TestCase):
         self.assertTrue(len(comments["data"]) == 0)
 
     # Test User
+    def test_create_user_not_allowed_login(self) -> None:
+        if self.public_test:
+            # Do not run that test against the public instance, it would create users.
+            return None
+        instance_config = self.client.get_config_info()
+        if not instance_config.get('registration'):
+            return None
+        for login in ["login", "user", "username", "help", "test", "about", "administration", "account"]:
+            user = self.client.create_user(name='test Name', login=login,
+                                        organisation='test Organization', email='test@testorg.local')
+            self.assertEqual(user['message'], 'Username not allowed.')
+
     def test_users_info(self) -> None:
         if not self.admin_token:
             # this test is only working if the admin token is set
@@ -299,7 +311,7 @@ class TestPublic(unittest.TestCase):
             return None
 
         user = self.client.create_user(name='test Name', login='alan',
-                                       organisation='test Organization', email='test@testorg.lu')
+                                       organisation='test Organization', email='test@testorg.local')
         self.assertTrue(user)
         self.assertTrue('id' in user, user)
         uid = user['id']

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -298,7 +298,7 @@ class TestPublic(unittest.TestCase):
         if not instance_config.get('registration'):
             return None
 
-        user = self.client.create_user(name='test Name', login='alan',
+        user = self.client.create_user(name='test Name', login='alan11111',
                                        organisation='test Organization', email='test@testorg.lu')
         self.assertTrue(user)
         self.assertTrue('id' in user, user)


### PR DESCRIPTION
The endpoints `redis_up`, `dbInfo`, and `configInfo` are now under `/api/system`.

All API endpoints related to vulnerabilities (CVE, PySec, GHSA, etc.) are under `/api/vulnerability` including the endpoints `last` and `browse`.

The interoperability with previous endpoints has been kept and the documentation is mentioning the change.
https://vulnerability.circl.lu/doc